### PR TITLE
fix(fiber): Fix fiber returning 500 internal server error

### DIFF
--- a/adapter/fiber.go
+++ b/adapter/fiber.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"fmt"
 )
 
 const contextUserValueKey = "github.com/its-felix/aws-lambda-go-http-adapter/adapter/fiber::contextUserValueKey"
@@ -58,9 +59,16 @@ func (a fiberAdapter) adapterFunc(ctx context.Context, r *http.Request, w http.R
 		}
 	}
 
-	// remoteAddr
-	remoteAddr, err := net.ResolveTCPAddr("tcp", r.RemoteAddr)
+	addrWithPort := r.RemoteAddr
+	if strings.Count(r.RemoteAddr, ":") > 3 { // IPv6
+		if !strings.Contains(r.RemoteAddr, "[") {
+			addrWithPort = fmt.Sprintf("[%s]:http",strings.Split(r.RemoteAddr, ":http")[0])
+		}
+	}
+
+	remoteAddr, err := net.ResolveTCPAddr("tcp", addrWithPort)
 	if err != nil {
+		fmt.Printf("could not resolve TCP address for addr %s\n", r.RemoteAddr)
 		return err
 	}
 


### PR DESCRIPTION
This merge request addresses an issue where the net.ResolveTCPAddr function fails to parse IPv6 addresses.

When using Fiber, Lambda URL, and IPv6, the value of r.RemoteAddr is formatted like this:

`
"2601:1702:4fb6:a31f:61c8:65c2:9d71:6599:http:"
`

Example code demonstrating the issue:

```

func main() {
    ip := "2601:1702:4fb6:a31f:61c8:65c2:9d71:6599:http:"
    _, err := net.ResolveTCPAddr("tcp", ip)
    if err != nil {
        fmt.Println(err)
    }
}

```
Running this code results in the following error:

`address 2601:1702:4fb6:a31f:61c8:65c2:9d71:6599:http:: too many colons in address
`

This merge request resolves the issue by adding square brackets to the address, converting it into a valid IPv6 format.

